### PR TITLE
Fix vCard name splitting

### DIFF
--- a/frontend/js/datatables_vcard_export.ts
+++ b/frontend/js/datatables_vcard_export.ts
@@ -34,7 +34,9 @@ export function vcard_export(e, dt, button, config) {
         const vcard = new VCard();
 
         if (columnName !== -1 && row[columnName]) {
-            const [firstName, lastName] = row[columnName].split(' ', 2); // TODO: this is stored as firstName and lastName in the db, find a better way to get this in JS...
+            const names = row[columnName].trim().split(/\s+/);
+            const firstName = names[0];
+            const lastName = names.length > 1 ? names[names.length - 1] : '';
             vcard.addName(firstName, lastName);
         }
 


### PR DESCRIPTION
## Summary
- fix the vCard export to correctly handle middle names by using the first word as first name and last word as last name

## Testing
- `./coverage.sh` *(fails: coverage not found)*
- `python manage.py test wwwapp` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68604e6e069c83289e588bf7cb0ee3cb